### PR TITLE
Add packaging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Intune Auto Package - Push To Intune
+
+This project provides a minimal graphical utility for packaging `.exe` or `.msi` files and uploading them as Win32 applications to Microsoft Intune.
+
+**Disclaimer:** This example is intentionally simple and does not fully replicate all features of a production ready packager. The Intune Graph API requires additional parameters and packaging steps which are not included here. Use at your own risk.
+
+## Usage
+
+1. Install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the `INTUNE_CLIENT_ID` environment variable with your Azure app registration client ID.
+
+3. Run the application:
+
+```bash
+python -m intune_packager.app
+```
+
+A window will appear. Drag and drop an `.exe` or `.msi` file onto the window. The script will attempt to detect silent install and uninstall commands and then upload the metadata to your Intune tenant using the device flow authentication.
+
+A zipped copy of the installer is created in the same directory. The package uploaded to Intune uses this zip file.
+
+## Requirements
+
+- Python 3.8+
+- Network connectivity to Azure
+- The `msal`, `requests` and `tkinterdnd2` packages
+
+## Building a Windows executable
+
+To generate a standalone `.exe` you can use [PyInstaller](https://pyinstaller.org/):
+
+```bash
+pip install pyinstaller
+./build_exe.bat
+```
+
+After the build finishes, run `dist\IntunePackager.exe`.
+
+## Testing
+
+Run tests with `pytest`:
+
+```bash
+pytest
+```
+
+Currently tests only cover simple command detection logic.

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -1,0 +1,7 @@
+@echo off
+pyinstaller --onefile -w -n IntunePackager src\intune_packager\app.py
+if %errorlevel% neq 0 (
+    echo Build failed
+    exit /b %errorlevel%
+)
+echo Executable created in dist\IntunePackager.exe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+msal
+requests
+tkinterdnd2
+pyinstaller; platform_system == "Windows"  # optional, for building the exe

--- a/src/intune_packager/app.py
+++ b/src/intune_packager/app.py
@@ -1,0 +1,25 @@
+from tkinterdnd2 import DND_FILES, TkinterDnD
+import tkinter as tk
+from .packager import create_intune_package
+
+
+def main():
+    root = TkinterDnD.Tk()
+    root.title("Intune Packager")
+    frame = tk.Frame(root, width=400, height=200, bg="lightgray")
+    frame.pack(padx=10, pady=10, fill="both", expand=True)
+    label = tk.Label(frame, text="Drag and drop .exe or .msi here", bg="lightgray")
+    label.pack(expand=True)
+
+    def drop(event):
+        file_path = event.data.strip('{}')
+        create_intune_package(file_path)
+
+    frame.drop_target_register(DND_FILES)
+    frame.dnd_bind("<<Drop>>", drop)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/intune_packager/intune_api.py
+++ b/src/intune_packager/intune_api.py
@@ -1,0 +1,40 @@
+import os
+import msal
+import requests
+
+AUTHORITY = 'https://login.microsoftonline.com/common'
+SCOPES = ['https://graph.microsoft.com/.default']
+GRAPH_URL = 'https://graph.microsoft.com/beta'
+CLIENT_ID = os.environ.get('INTUNE_CLIENT_ID', 'YOUR_CLIENT_ID')
+
+
+class IntuneClient:
+    def __init__(self):
+        self.app = msal.PublicClientApplication(client_id=CLIENT_ID, authority=AUTHORITY)
+        self.token = None
+
+    def authenticate(self):
+        if not self.token:
+            flow = self.app.initiate_device_flow(scopes=SCOPES)
+            if 'message' in flow:
+                print(flow['message'])
+            self.token = self.app.acquire_token_by_device_flow(flow)
+        return self.token
+
+    def upload_win32_app(self, file_path: str, install_cmd: str, uninstall_cmd: str):
+        token = self.authenticate()
+        access_token = token.get('access_token')
+        headers = {
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': 'application/json'
+        }
+        data = {
+            'displayName': os.path.basename(file_path),
+            'description': 'Uploaded via Intune Packager',
+            'installCommandLine': install_cmd,
+            'uninstallCommandLine': uninstall_cmd
+        }
+        print('Uploading metadata to Intune...')
+        response = requests.post(f'{GRAPH_URL}/deviceAppManagement/mobileApps', headers=headers, json=data)
+        response.raise_for_status()
+        print('Upload finished.')

--- a/src/intune_packager/packager.py
+++ b/src/intune_packager/packager.py
@@ -1,0 +1,29 @@
+import os
+import zipfile
+
+
+def detect_commands(file_path: str):
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == '.msi':
+        install = f'msiexec /i "{file_path}" /qn /norestart'
+        uninstall = f'msiexec /x "{file_path}" /qn /norestart'
+    else:
+        install = f'"{file_path}" /S'
+        uninstall = ''  # Could not detect
+    return install, uninstall
+
+
+def create_zip(file_path: str) -> str:
+    """Create a zipped copy of the installer and return the zip path."""
+    zip_path = os.path.splitext(file_path)[0] + '.zip'
+    with zipfile.ZipFile(zip_path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(file_path, arcname=os.path.basename(file_path))
+    return zip_path
+
+
+def create_intune_package(file_path: str):
+    install_cmd, uninstall_cmd = detect_commands(file_path)
+    zip_path = create_zip(file_path)
+    from .intune_api import IntuneClient
+    client = IntuneClient()
+    client.upload_win32_app(zip_path, install_cmd, uninstall_cmd)

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -1,0 +1,25 @@
+import sys, os; sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from intune_packager.packager import detect_commands, create_zip
+
+
+def test_msi_commands():
+    install, uninstall = detect_commands('setup.msi')
+    assert 'msiexec' in install
+    assert '/i' in install
+    assert 'msiexec' in uninstall
+
+
+def test_exe_commands():
+    install, uninstall = detect_commands('setup.exe')
+    assert install.endswith('/S')
+    assert uninstall == ''
+
+
+def test_create_zip(tmp_path):
+    dummy = tmp_path / 'dummy.exe'
+    dummy.write_text('123')
+    zip_path = create_zip(str(dummy))
+    assert os.path.exists(zip_path)
+    import zipfile
+    with zipfile.ZipFile(zip_path) as zf:
+        assert zf.namelist() == ['dummy.exe']


### PR DESCRIPTION
## Summary
- create `create_zip` to produce an archive for upload
- update README with zip details and instructions to build a Windows executable
- add a simple `build_exe.bat` helper script
- ignore PyInstaller output directories
- test new `create_zip` function

## Testing
- `pytest -q`
